### PR TITLE
fix: Keep shared secret in memory if approved by user

### DIFF
--- a/src/block/signer.c
+++ b/src/block/signer.c
@@ -164,7 +164,7 @@ static int signer_inject_seed(signer_ctx_t *signer, block_command_t *command) {
     // Set the shared secret in the stream
     memcpy(G_context.stream.shared_secret, xpriv, sizeof(xpriv));
     G_context.stream.shared_secret_len = sizeof(xpriv);
-
+   
     // User approval
     ui_display_add_seed_command();
 
@@ -175,10 +175,9 @@ int add_seed_callback(bool confirm) {
     if (confirm) {
         io_send_trusted_property(SW_OK);
     } else {
+        explicit_bzero(G_context.stream.shared_secret, G_context.stream.shared_secret_len);
         io_send_sw(SW_DENY);
     }
-    explicit_bzero(G_context.stream.shared_secret, G_context.stream.shared_secret_len);
-
     return 0;
 }
 


### PR DESCRIPTION
Fix a bug when the client is trying to create a block containing a Seed and PublishKey command.
Seed was reset wether action was approved or not by the user making chained command undoable.

# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [ x ] App update process has been followed <!-- See comment below -->
- [ x ] Target branch is `develop` <!-- unless you have a very good reason -->
- [ x ] Application version has been bumped <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/device-app/deliver/maintenance before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->
